### PR TITLE
Have a working SauceLabs configuration in the repository

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,5 @@ charset = utf-8
 [*.js]
 indent_size = 4
 
-[{package.json,.travis.yml}]
+[{package.json,.travis.yml,Gruntfile.js}]
 indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ before_install:
   - "sh -e /etc/init.d/xvfb start"
   - npm install -g grunt-cli
 
+script:
+  - grunt travis
+
 env:
   global:
     - secure: SSkMWT8NymHCgYRkTdUR+6dXtf4hG5rPwjWHLuXKK8MgLMXdyI9yyf8r9jiJj4GMI/ZSbXMXKCqgHmwXW7zxKoWiyqht44xOG5HVaLKlLHJQpShwLNJC8EL7rtUJhaC9Qbjfch2PwHb9TqeTIqqbsns/TxPDK5PUwABaTScCDEI=
     - secure: gfYIkx0XD8zFJEu1vTWairTpafE/3pSvBW2K9jwrQFhpHsyXXGPTRw8YafBf01B/HJ/1B+SIM7QG3yYs6CY1wBVs1GAs/f1aqSZDDoQvi6lYN747LkM2M2dcORX2GpybA3hGaRajs4Xkfu4Poi9kXMyleh/Yzbd3n+vv61c0dnM=
-
-addons:
-  sauce_connect: true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,31 @@
 module.exports = function(grunt) {
 
+  var sauceLaunchers = {
+    sl_chrome: {
+      base: 'SauceLabs',
+      browserName: 'chrome',
+      platform: 'Windows 7',
+      version: '35'
+    },
+    sl_firefox: {
+      base: 'SauceLabs',
+      browserName: 'firefox',
+      version: '30'
+    },
+    sl_ios_safari: {
+      base: 'SauceLabs',
+      browserName: 'iphone',
+      platform: 'OS X 10.9',
+      version: '7.1'
+    },
+    sl_ie_11: {
+      base: 'SauceLabs',
+      browserName: 'internet explorer',
+      platform: 'Windows 8.1',
+      version: '11'
+    }
+  };
+
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     jshint: {
@@ -35,10 +61,21 @@ module.exports = function(grunt) {
       tasks: ['build']
     },
     karma: {
-      integration: {
+      local: {
         configFile: 'karma.conf.js',
         options: {
-            browsers: ['PhantomJS']
+          browsers: ['PhantomJS']
+        }
+      },
+      sauce: {
+        configFile: 'karma.conf.js',
+        options: {
+          reporters: ['saucelabs', 'spec'],
+          sauceLabs: {
+            public: 'public',
+          },
+          customLaunchers: sauceLaunchers,
+          browsers: Object.keys(sauceLaunchers)
         }
       }
     }
@@ -46,7 +83,9 @@ module.exports = function(grunt) {
 
   require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
 
-  grunt.registerTask('test', ['jshint', 'mochaTest', 'karma']);
+  grunt.registerTask('test', ['jshint', 'mochaTest', 'karma:local']);
+
+  grunt.registerTask('travis', ['test', 'karma:sauce']);
 
   grunt.registerTask('build', ['test', 'browserify', 'uglify']);
 

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "karma": "^0.12.23",
     "karma-mocha": "^0.1.9",
     "karma-phantomjs-launcher": "^0.1.4",
+    "karma-sauce-launcher": "git://github.com/bripkens/karma-sauce-launcher.git#job-visibility",
     "karma-bro": "^0.7.0",
     "karma-spec-reporter": "0.0.13",
-    "grunt-karma": "^0.9.0",
-    "karma-sauce-launcher": "^0.2.10"
+    "grunt-karma": "^0.9.0"
   }
 }


### PR DESCRIPTION
It should be possible to locally execute tests against SauceLabs.
Add a second karma Grunt goal through which this can be achieved.

Will have to use my fork of the Karma Sauce Launcher until the PR [1]
has been incorporated.

[1] https://github.com/karma-runner/karma-sauce-launcher/pull/56