### PR TITLE
Store mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,33 @@ statusStore.exampleMethod('arg1');
 // Should output: 'arg1'
 ```
 
+#### Mixins in stores
+
+Just as you can add mixins to React components, so it is possible to add your mixins to Store.
+
+```javascript
+var MyMixin = { foo: function() { console.log('bar!'); } }
+var Store = Reflux.createStore({
+    mixins: [MyMixin]
+});
+Store.foo(); // outputs "bar!" to console
+```
+
+Methods from mixins is available as well as the methods declared in the Store. So it's possible to access store's `this` from mixin, or methods of mixin from methods of store:
+
+```javascript
+var MyMixin = { mixinMethod: function() { console.log(this.foo); } }
+var Store = Reflux.createStore({
+    mixins: [MyMixin],
+    foo: 'bar!',
+    storeMethod: function() {
+        this.mixinMethod(); // outputs "bar!" to console
+    }
+});
+```
+
+A nice feature of mixins is that if a store is using multiple mixins and several mixins define the same lifecycle method (e.g. `init`, `preEmit`, `shouldEmit`), all of the lifecycle methods are guaranteed to be called.
+
 #### Listening to many actions at once
 
 Since it is a very common pattern to listen to all actions from a `createActions` call in a store `init` call, the store has a `listenToMany` function that takes an object of listenables. Instead of doing this:

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,6 +1,7 @@
 var _ = require('./utils'),
     Reflux = require('./index'),
     Keep = require('./Keep'),
+    mixer = require('./mixer'),
     allowed = {preEmit:1,shouldEmit:1},
     bindMethods = require('./bindMethods');
 
@@ -31,6 +32,8 @@ module.exports = function(definition) {
             );
         }
     }
+
+    definition = mixer(definition);
 
     function Store() {
         var i=0, arr;

--- a/src/mixer.js
+++ b/src/mixer.js
@@ -18,11 +18,11 @@ module.exports = function mix(def) {
                 composed[composable].push(mixin[composable]);
             }
         });
-        def = _.merge({}, mixin, def);
+        def = _.extend({}, mixin, def);
         return def;
     }(def));
 
-    if (composed.init.length) {
+    if (composed.init.length > 1) {
         updated.init = function () {
             var args = arguments;
             composed.init.forEach(function (init) {
@@ -30,14 +30,14 @@ module.exports = function mix(def) {
             }, this);
         };
     }
-    if (composed.preEmit.length) {
+    if (composed.preEmit.length > 1) {
         updated.preEmit = function () {
             return composed.preEmit.reduce(function (args, preEmit) {
                 return preEmit.apply(this, args) || args;
             }, arguments, this);
         };
     }
-    if (composed.shouldEmit.length) {
+    if (composed.shouldEmit.length > 1) {
         updated.shouldEmit = function () {
             var args = arguments;
             return composed.shouldEmit.some(function (shouldEmit) {
@@ -45,6 +45,11 @@ module.exports = function mix(def) {
             }, this);
         };
     }
+    Object.keys(composed).forEach(function (composable) {
+        if (composed[composable].length === 1) {
+            updated[composable] = composed[composable][0];
+        }
+    });
 
     return updated;
 };

--- a/src/mixer.js
+++ b/src/mixer.js
@@ -1,0 +1,50 @@
+var _ = require('./utils');
+
+module.exports = function mix(def) {
+    var composed = {
+        init: [],
+        preEmit: [],
+        shouldEmit: []
+    };
+
+    var updated = (function mixDef(mixin) {
+        if (mixin.mixins) {
+            mixin.mixins.forEach(function (mixin) {
+                mixDef(mixin);
+            });
+        }
+        Object.keys(composed).forEach(function (composable) {
+            if (mixin.hasOwnProperty(composable)) {
+                composed[composable].push(mixin[composable]);
+            }
+        });
+        def = _.merge({}, mixin, def);
+        return def;
+    }(def));
+
+    if (composed.init.length) {
+        updated.init = function () {
+            var args = arguments;
+            composed.init.forEach(function (init) {
+                init.apply(this, args);
+            }, this);
+        };
+    }
+    if (composed.preEmit.length) {
+        updated.preEmit = function () {
+            return composed.preEmit.reduce(function (args, preEmit) {
+                return preEmit.apply(this, args) || args;
+            }, arguments, this);
+        };
+    }
+    if (composed.shouldEmit.length) {
+        updated.shouldEmit = function () {
+            var args = arguments;
+            return composed.shouldEmit.some(function (shouldEmit) {
+                return shouldEmit.apply(this, args);
+            }, this);
+        };
+    }
+
+    return updated;
+};

--- a/test/storeMixins.spec.js
+++ b/test/storeMixins.spec.js
@@ -1,0 +1,193 @@
+var chai = require('chai'),
+    assert = chai.assert,
+    Reflux = require('../src'),
+    sinon = require('sinon');
+
+describe('Creating stores with mixins', function () {
+    describe('with one simple mixin', function () {
+        var mixin = {
+                foo: 'FOO'
+            },
+            def = {
+                mixins: [mixin],
+                bar: 'BAR'
+            },
+            store = Reflux.createStore(def);
+
+        it('should extend store with mixins props', function () {
+            assert.equal(store.foo, mixin.foo);
+            assert.equal(store.bar, def.bar);
+        });
+    });
+    describe('with mixin with same property key', function () {
+        var bar = 'BAR',
+            baz = 'BAZ',
+            mixin = {
+                foo: 'FOO',
+                init: sinon.spy(),
+                preEmit: sinon.stub().returns(bar),
+                shouldEmit: sinon.stub().returns(true)
+            },
+            def = {
+                mixins: [mixin],
+                foo: 'DEF_FOO',
+                init: sinon.spy(),
+                preEmit: sinon.stub().returns(baz),
+                shouldEmit: sinon.stub().returns(true)
+            },
+            store = Reflux.createStore(def),
+            listener = sinon.spy();
+
+        store.listen(listener);
+        store.trigger('triggered');
+
+        it('should use def over mixin', function () {
+            assert.equal(store.foo, def.foo);
+        });
+        it('should call both init', function () {
+            assert.equal(mixin.init.callCount, 1);
+            assert.equal(def.init.callCount, 1);
+        });
+        it('should call mixin init before def init', function () {
+            assert(mixin.init.calledBefore(def.init));
+        });
+        it('should compose preEmit', function () {
+            assert.equal(mixin.preEmit.callCount, 1);
+            assert.equal(def.preEmit.callCount, 1);
+
+            assert(mixin.preEmit.calledWith('triggered'));
+            assert(def.preEmit.calledWith(bar));
+            assert(listener.calledWith(baz));
+
+            assert(mixin.preEmit.calledBefore(def.preEmit));
+        });
+        it('should compose shouldEmit', function () {
+            assert.equal(mixin.shouldEmit.callCount, 1);
+            assert.equal(def.shouldEmit.callCount, 1);
+
+            assert(mixin.shouldEmit.calledWith(baz));
+            assert(def.shouldEmit.calledWith(baz));
+
+            assert(mixin.shouldEmit.calledBefore(def.shouldEmit));
+        });
+    });
+    describe('with falsey shouldEmit in mixin', function () {
+        var mixin = {
+                shouldEmit: sinon.stub().returns(false)
+            },
+            def = {
+                mixins: [mixin],
+                shouldEmit: sinon.stub().returns(true)
+            },
+            store = Reflux.createStore(def),
+            listener = sinon.spy();
+
+        store.listen(listener);
+        store.trigger('triggered');
+
+        it('should not trigger', function () {
+            assert.equal(mixin.shouldEmit.callCount, 1);
+            assert.equal(listener.callCount, 0);
+        });
+        it('should not call def shouldEmit', function () {
+            assert.equal(def.shouldEmit.callCount, 0);
+        });
+    });
+    describe('with void preEmit in mixin', function () {
+        var mixin = {
+                preEmit: sinon.spy()
+            },
+            def = {
+                mixins: [mixin],
+                preEmit: sinon.spy()
+            },
+            store = Reflux.createStore(def),
+            listener = sinon.spy();
+
+        store.listen(listener);
+        store.trigger('triggered');
+
+        it('should not change triggered value', function () {
+            assert.equal(mixin.preEmit.callCount, 1);
+            assert.equal(def.preEmit.callCount, 1);
+
+            assert(mixin.preEmit.calledWith('triggered'));
+            assert(def.preEmit.calledWith('triggered'));
+            assert(listener.calledWith('triggered'));
+
+            assert(mixin.preEmit.calledBefore(def.preEmit));
+        });
+    });
+    describe('with mixins in mixin', function () {
+        var bar = 'BAR',
+            baz = 'BAZ',
+            goo = 'GOO',
+            subMixin = {
+                subFoo: 'SUB_FOO',
+                subBar: 'SUB_BAR',
+                init: sinon.spy(),
+                preEmit: sinon.stub().returns(goo),
+                shouldEmit: sinon.stub().returns(true)
+            },
+            mixin = {
+                mixins: [subMixin],
+                foo: 'FOO',
+                subFoo: 'SUB_FOO_PARENT',
+                init: sinon.spy(),
+                preEmit: sinon.stub().returns(bar),
+                shouldEmit: sinon.stub().returns(true)
+            },
+            def = {
+                mixins: [mixin],
+                foo: 'DEF_FOO',
+                init: sinon.spy(),
+                preEmit: sinon.stub().returns(baz),
+                shouldEmit: sinon.stub().returns(true)
+            },
+            store = Reflux.createStore(def),
+            listener = sinon.spy();
+
+        store.listen(listener);
+        store.trigger('triggered');
+
+        it('should extend store with props from subMixin', function () {
+            assert.equal(store.subBar, subMixin.subBar);
+        });
+        it('should use mixin over subMixin', function () {
+            assert.equal(store.subFoo, mixin.subFoo);
+        });
+        it('should call all inits', function () {
+            assert.equal(subMixin.init.callCount, 1);
+            assert.equal(mixin.init.callCount, 1);
+            assert.equal(def.init.callCount, 1);
+        });
+        it('should call subMixin init before mixin init', function () {
+            assert(subMixin.init.calledBefore(mixin.init));
+        });
+        it('should compose preEmit', function () {
+            assert.equal(subMixin.preEmit.callCount, 1);
+            assert.equal(mixin.preEmit.callCount, 1);
+            assert.equal(def.preEmit.callCount, 1);
+
+            assert(subMixin.preEmit.calledWith('triggered'));
+            assert(mixin.preEmit.calledWith(goo));
+            assert(def.preEmit.calledWith(bar));
+            assert(listener.calledWith(baz));
+
+            assert(subMixin.preEmit.calledBefore(mixin.preEmit));
+            assert(mixin.preEmit.calledBefore(def.preEmit));
+        });
+        it('should compose shouldEmit', function () {
+            assert.equal(subMixin.shouldEmit.callCount, 1);
+            assert.equal(mixin.shouldEmit.callCount, 1);
+            assert.equal(def.shouldEmit.callCount, 1);
+
+            assert(subMixin.shouldEmit.calledWith(baz));
+            assert(mixin.shouldEmit.calledWith(baz));
+            assert(def.shouldEmit.calledWith(baz));
+
+            assert(subMixin.shouldEmit.calledBefore(mixin.shouldEmit));
+            assert(mixin.shouldEmit.calledBefore(def.shouldEmit));
+        });
+    });
+});


### PR DESCRIPTION
Just implemented very simple version.
Need feedback about spec I intend to implement.
Especially about `init`, `preEmit` and `shouldEmit` methods.
I think, it'll be cool to add possibility to mixin multiple init methods. Some mixins can require `init` for it's needs, but let user to write another `init` in store defenition. Same about `preEmit` and `shouldEmit`

Also updated Grunt version in package.json. Only with `0.4.0` `npm install` works for me. Otherwise it errors about Grunt version
```
The package grunt does not satisfy its siblings' peerDependencies requirements!
```
Not sure is this fix is ok.