### PR TITLE
Child (async) actions and promise handling

### DIFF
--- a/src/createAction.js
+++ b/src/createAction.js
@@ -34,7 +34,7 @@ var createAction = function(definition) {
     }
 
     definition.children = definition.children || [];
-    if (definition.async){
+    if (definition.asyncResult){
         definition.children = definition.children.concat(["completed","failed"]);
     }
 

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -10,9 +10,12 @@ var _ = require('./utils'),
  *
  * @param {Object} definition The action object definition
  */
-module.exports = function(definition) {
+var createAction = function(definition) {
 
     definition = definition || {};
+    if (!_.isObject(definition)){
+        definition = {name: definition};
+    }
 
     for(var a in Reflux.ActionMethods){
         if (!allowed[a] && Reflux.PublisherMethods[a]) {
@@ -30,6 +33,17 @@ module.exports = function(definition) {
         }
     }
 
+    definition.children = definition.children || [];
+    if (definition.async){
+        definition.children = definition.children.concat(["completed","failed"]);
+    }
+
+    var i = 0, childActions = {};
+    for (; i < definition.children.length; i++) {
+        var name = definition.children[i];
+        childActions[name] = createAction(name);
+    }
+
     var context = _.extend({
         eventLabel: "action",
         emitter: new _.EventEmitter(),
@@ -40,10 +54,12 @@ module.exports = function(definition) {
         functor[functor.sync?"trigger":"triggerAsync"].apply(functor, arguments);
     };
 
-    _.extend(functor,context);
+    _.extend(functor,childActions,context);
 
     Keep.createdActions.push(functor);
 
     return functor;
 
 };
+
+module.exports = createAction;

--- a/src/index.js
+++ b/src/index.js
@@ -29,17 +29,21 @@ exports.joinStrict = maker("strict");
 
 exports.joinConcat = maker("all");
 
+var _ = require('./utils');
 
 /**
  * Convenience function for creating a set of actions
  *
- * @param actionNames the names for the actions to be created
+ * @param definitions the definitions for the actions to be created
  * @returns an object with actions of corresponding action names
  */
-exports.createActions = function(actionNames) {
-    var i = 0, actions = {};
-    for (; i < actionNames.length; i++) {
-        actions[actionNames[i]] = exports.createAction();
+exports.createActions = function(definitions) {
+    var actions = {};
+    for (var k in definitions){
+        var val = definitions[k],
+            actionName = _.isObject(val) ? k : val;
+
+        actions[actionName] = exports.createAction(val);
     }
     return actions;
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,8 +31,12 @@ exports.nextTick = function(callback) {
     setTimeout(callback, 0);
 };
 
+exports.capitalize = function(string){
+    return string.charAt(0).toUpperCase()+string.slice(1);
+};
+
 exports.callbackName = function(string){
-    return "on"+string.charAt(0).toUpperCase()+string.slice(1);
+    return "on"+exports.capitalize(string);
 };
 
 exports.object = function(keys,vals){

--- a/test/creatingActions.spec.js
+++ b/test/creatingActions.spec.js
@@ -35,10 +35,10 @@ describe('Creating action', function() {
     });
 
     it("should create completed and failed child actions for async actions",function(){
-        var def = {async: true},
+        var def = {asyncResult: true, sync: true},
             action = Reflux.createAction(def);
 
-        assert.equal(action.async, true);
+        assert.equal(action.asyncResult, true);
         assert.deepEqual(action.children, ["completed", "failed"]);
         assert.equal(action.completed._isAction, true);
         assert.equal(action.failed._isAction, true);
@@ -207,7 +207,7 @@ describe('Creating actions with children to an action definition object', functi
     var actionNames, actions;
 
     beforeEach(function () {
-        actionNames = {'foo': {async: true}, 'bar': {children: ['baz']}};
+        actionNames = {'foo': {asyncResult: true}, 'bar': {children: ['baz']}};
         actions = Reflux.createActions(actionNames);
     });
 

--- a/test/creatingActions.spec.js
+++ b/test/creatingActions.spec.js
@@ -23,6 +23,28 @@ describe('Creating action', function() {
         assert.equal(action.random, def.random);
     });
 
+    it("should create specified child actions",function(){
+        var def = {children: ["foo","BAR"]},
+            action = Reflux.createAction(def);
+
+        assert.deepEqual(action.children, ["foo", "BAR"]);
+        assert.equal(action.foo._isAction, true);
+        assert.deepEqual(action.foo.children, []);
+        assert.equal(action.BAR._isAction, true);
+
+    });
+
+    it("should create completed and failed child actions for async actions",function(){
+        var def = {async: true},
+            action = Reflux.createAction(def);
+
+        assert.equal(action.async, true);
+        assert.deepEqual(action.children, ["completed", "failed"]);
+        assert.equal(action.completed._isAction, true);
+        assert.equal(action.failed._isAction, true);
+    });
+
+
     it("should throw an error if you overwrite any API other than preEmit and shouldEmit",function(){
         assert.throws(function(){
             Reflux.createAction({listen:"FOO"});
@@ -181,6 +203,79 @@ describe('Creating action', function() {
 
 });
 
+describe('Creating actions with children to an action definition object', function() {
+    var actionNames, actions;
+
+    beforeEach(function () {
+        actionNames = {'foo': {async: true}, 'bar': {children: ['baz']}};
+        actions = Reflux.createActions(actionNames);
+    });
+
+    it('should contain foo and bar properties', function() {
+        assert.property(actions, 'foo');
+        assert.property(actions, 'bar');
+    });
+
+    it('should contain action functor on foo and bar properties with children', function() {
+        assert.isFunction(actions.foo);
+        assert.isFunction(actions.foo.completed);
+        assert.isFunction(actions.foo.failed);
+        assert.isFunction(actions.bar);
+        assert.isFunction(actions.bar.baz);
+    });
+
+    describe('when listening to the child action created this way', function() {
+        var promise;
+
+        beforeEach(function() {
+            promise = Q.promise(function(resolve) {
+                actions.bar.baz.listen(function() {
+                    resolve(Array.prototype.slice.call(arguments, 0));
+                }, {}); // pass empty context
+            });
+        });
+
+        it('should receive the correct arguments', function() {
+            var testArgs = [1337, 'test'];
+            actions.bar.baz(testArgs[0], testArgs[1]);
+
+            return assert.eventually.deepEqual(promise, testArgs);
+        });
+    });
+
+    describe('when promising an async action created this way', function() {
+        var promise;
+
+        beforeEach(function() {
+            // promise resolves on foo.completed
+            promise = Q.promise(function(resolve) {
+                actions.foo.completed.listen(function(){
+                    resolve.apply(null, arguments);
+                }, {}); // pass empty context
+            });
+
+            // listen for foo and return a promise
+            actions.foo.listenAndPromise(function() {
+                var args = Array.prototype.slice.call(arguments, 0);
+                var deferred = Q.defer();
+
+                setTimeout(function() {
+                    deferred.resolve(args);
+                }, 0);
+
+                return deferred.promise;
+            });
+        });
+
+        it('should invoke the completed action with the correct arguments', function() {
+            var testArgs = [1337, 'test'];
+            actions.foo(testArgs[0], testArgs[1]);
+
+            return assert.eventually.deepEqual(promise, testArgs);
+        });
+    });
+});
+
 describe('Creating multiple actions to an action definition object', function() {
 
     var actionNames, actions;
@@ -207,8 +302,9 @@ describe('Creating multiple actions to an action definition object', function() 
         beforeEach(function() {
             promise = Q.promise(function(resolve) {
                 actions.foo.listen(function() {
+                    assert.equal(this, actions.foo);
                     resolve(Array.prototype.slice.call(arguments, 0));
-                });
+                }); // not passing context, should default to action
             });
         });
 

--- a/test/usingListenerMethodsMixin.spec.js
+++ b/test/usingListenerMethodsMixin.spec.js
@@ -7,21 +7,32 @@ describe("using the ListenerMethods",function(){
     var ListenerMethods = Reflux.ListenerMethods;
 
     describe("the listenToMany function",function(){
-        var listenables = { foo: "FOO", bar: "BAR", baz: "BAZ", missing: "MISSING"},
+        var listenables = { foo: "FOO", bar: "BAR", baz: "BAZ", missing: "MISSING", parent: {
+                children: ['foo', 'bar', 'baz', "notThere"], foo: "FOOChild", bar: "BARChild", baz: "BAZChild"
+            }},
             context = {
                 onFoo:"onFoo",
                 bar:"bar",
                 onBaz:"onBaz",
                 onBazDefault:"onBazDefault",
+                onParent: "onParent",
+                onParentFoo: "onParentFoo",
+                parentBar: "parentBar",
+                onParentBaz: "onParentBaz",
+                onParentBazDefault: "onParentBazDefault",
                 listenTo:sinon.spy()
             };
         Reflux.ListenerMixin.listenToMany.call(context,listenables);
 
         it("should call listenTo for all listenables with corresponding callbacks",function(){
-            assert.equal(context.listenTo.callCount,3);
+            assert.equal(context.listenTo.callCount,7);
             assert.deepEqual(context.listenTo.firstCall.args,[listenables.foo,"onFoo","onFoo"]);
             assert.deepEqual(context.listenTo.secondCall.args,[listenables.bar,"bar","bar"]);
             assert.deepEqual(context.listenTo.thirdCall.args,[listenables.baz,"onBaz","onBazDefault"]);
+            assert.deepEqual(context.listenTo.getCall(3).args,[listenables.parent,"onParent","onParent"]);
+            assert.deepEqual(context.listenTo.getCall(4).args,[listenables.parent.foo,"onParentFoo","onParentFoo"]);
+            assert.deepEqual(context.listenTo.getCall(5).args,[listenables.parent.bar,"parentBar","parentBar"]);
+            assert.deepEqual(context.listenTo.getCall(6).args,[listenables.parent.baz,"onParentBaz","onParentBazDefault"]);
         });
     });
 

--- a/test/usingPublisherMethodsMixin.spec.js
+++ b/test/usingPublisherMethodsMixin.spec.js
@@ -1,10 +1,66 @@
 var chai = require('chai'),
     assert = chai.assert,
     Reflux = require('../src'),
+    Q = require('q'),
     sinon = require('sinon');
 
 describe("using the publisher methods mixin",function(){
     var pub = Reflux.PublisherMethods;
+
+    describe("the promise method",function(){
+
+        describe("when the promise completes",function(){
+            var deferred = Q.defer(),
+                promise = deferred.promise,
+                context = {
+                    children:['completed','failed'],
+                    completed:sinon.spy(),
+                    failed:sinon.spy()
+                },
+                result = pub.promise.call(context,promise);
+
+            deferred.resolve('foo');
+
+            it("should not return a value",function(){
+                assert.equal(result, undefined);
+            });
+
+            it("should call the completed child trigger",function(){
+                var args = context.completed.firstCall.args;
+                assert.deepEqual(args, ["foo"]);
+            });
+
+            it("should not call the failed child trigger",function(){
+                assert.equal(context.failed.callCount, 0);
+            });
+        });
+
+        describe("when the promise fails",function(){
+            var deferred = Q.defer(),
+                promise = deferred.promise,
+                context = {
+                    children:['completed','failed'],
+                    completed:sinon.spy(),
+                    failed:sinon.spy()
+                },
+                result = pub.promise.call(context,promise);
+
+            deferred.reject('bar');
+
+            it("should not return a value",function(){
+                assert.equal(result, undefined);
+            });
+
+            it("should call the failed child trigger",function(){
+                var args = context.failed.firstCall.args;
+                assert.deepEqual(args, ["bar"]);
+            });
+
+            it("should not the completed child trigger",function(){
+                assert.equal(context.completed.callCount, 0);
+            });
+        });
+    });
 
     describe("the listen method",function(){
         var emitter = {


### PR DESCRIPTION
# Async actions
There has been some discussion on asynchronous actions (https://github.com/spoike/refluxjs/issues/57, https://github.com/spoike/refluxjs/pull/103) and where to best handle them.

The consensus seems to be that triggered **execution is best kept outside of the stores**, and I personally agree. In my opinion, the store shouldn't worry about how actions are run, focusing merely on their results. It also makes testing easier, as a few folks have noted.

The pattern proposed in the [update on v0.1.8](http://spoike.ghost.io/refluxjs-0-1-8/) links the execution of asynchronous code to the preEmit hook of an action, after which it triggers events on "Completed" and "Failed" actions, like so: 

```javascript
var ProductAPI = require('./ProductAPI');  
// contains `load` method that returns a promise

var ProductActions = Reflux.createActions({  
    'load',         // initiates the async load
    'loadComplete', // when the load is complete
    'loadError'     // when the load has failed
});

// Hook up the API call in the load action's preEmit
ProductActions.load.preEmit = function () {  
     // Perform the API call, get a promise
     ProductAPI.load()
          .then(ProductActions.loadComplete)
          .catch(ProductActions.loadError);
};
```

## Issues with preEmit
While this is definitely the cleanest way I've seen, some things still bothered me about it:

* There is **no semantic link** between the "load" and "loadComplete" / "loadError" events. Nothing in the interface reflects the fact that they are related.

* Putting an API call, or some other asynchronous code, in the **preEmit hook seems hacky** to me. Others have expressed similar sentiments (https://github.com/spoike/refluxjs/issues/57).

* I think it's **overly verbose**. There's still some unnecessary boilerplate here, and for every async event (of which there can be loads) we have to now manually define 3 separate actions. If at some point we want to add a "Canceled" action as well for all our calls, we'll be doing busy-work for a while.

## Proposal: Child actions
It appeared to me that if we could define child actions (attached to a parent action), we could design a much nicer interface. This commit is an implementation of that idea. The general interface looks as such:

```javascript
// ProductActions.js

var ProductAPI = require('./ProductAPI');  
// contains `load` method that returns a promise

// Define action with child actions
var ProductActions = Reflux.createActions({  
    'load': {children: ['completed','failed']}
});

// And here is how you would hook it up to a promise
ProductActions.load.listen( function() {
    // Bind listener context to action by default
    ProductAPI.load()
        .then(this.completed)
        .catch(this.failed);
});
````
```javascript
// ProductStore.js

var ProductActions = require('./ProductActions');

// This is how you would listen for a completed load
ProductActions.load.completed.listen(function(result) {
    // do something with result
});

// listenToMany (and ListenerMixin) will still work intuitively
var Store = Reflux.createStore({
    init: function() {
        this.listenToMany(ProductActions);
    },
    onLoad: function(){
        // product load started
    },
    onLoadCompleted: function(product){
        // product load completed
    }
});
````

## Common-case helpers
I figured it would make sense as well to provide some helper methods and options to make the 80% case easier. This works as such:

````javascript
// Define actions with async option to auto-create
// 'completed' and 'failed' child events
var ProductActions = Reflux.createActions({  
    'load': {async: true}
});

// Hook up standard async child functors
// to a promise easily:
ProductActions.load.listen( function() {
    // Have the action attach callbacks to the promise
    // and pass on data to "complete" and "failed" actions
    ProductActions.load.promise(ProductAPI.load());
});

// Or even easier for the 80% case, a method that
// hooks ups callbacks to a returned promise directly
ProductActions.load.listenAndPromise( function() {
    return ProductAPI.load();
});
````

## Alternative uses
For custom cases, you could create alternative children events:
````javascript
var ImageAPI = require('./ImageAPI');

// If we need custom child actions, we could do so:
var ImageActions = Reflux.createActions({
    'pictureUpload': {children: ['progressed','completed']}
});

// Hook things up to a non-promise-based API
ImageActions.pictureUpload.listen(function(){
    ImageAPI.upload({
        onProgress: this.progressed,
        onSuccess: this.completed
    });
});
```

## Notes
Note, while createActions now operates on an associative Object, the interface remains backwards-compatible and accepts Arrays as well. 

This has cleaned up my action definitions quite a bit. Curious to hear your critical thoughts / feedback! Thanks!