### PR TITLE
Bind store methods before init() method executes.

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -37,6 +37,7 @@ module.exports = function(definition) {
         this.subscriptions = [];
         this.emitter = new _.EventEmitter();
         this.eventLabel = "change";
+        bindMethods(this, definition);
         if (this.init && _.isFunction(this.init)) {
             this.init();
         }
@@ -51,7 +52,6 @@ module.exports = function(definition) {
     _.extend(Store.prototype, Reflux.ListenerMethods, Reflux.PublisherMethods, Reflux.StoreMethods, definition);
 
     var store = new Store();
-    bindMethods(store, definition);
     Keep.createdStores.push(store);
 
     return store;

--- a/test/creatingStores.spec.js
+++ b/test/creatingStores.spec.js
@@ -234,9 +234,9 @@ describe('Creating stores', function() {
                 store = Reflux.createStore(def);
 
             it("should listenTo all listenables with the corresponding callbacks",function(){
-                assert.deepEqual(listenables.foo.listen.firstCall.args,[def.onFoo,store]);
-                assert.deepEqual(listenables.bar.listen.firstCall.args,[def.bar,store]);
-                assert.deepEqual(listenables.baz.listen.firstCall.args,[def.onBaz,store]);
+                assert.deepEqual(listenables.foo.listen.firstCall.args,[store.onFoo,store]);
+                assert.deepEqual(listenables.bar.listen.firstCall.args,[store.bar,store]);
+                assert.deepEqual(listenables.baz.listen.firstCall.args,[store.onBaz,store]);
             });
 
             it("should not try to listen to actions without corresponding props in the store",function(){
@@ -320,14 +320,18 @@ describe('Creating stores', function() {
     });
 
     describe('store methods', function() {
-        var store;
-
-        beforeEach(function() {
+        var initReflect,
             store = Reflux.createStore({
+                init: function() {
+                    initReflect = this.reflect;
+                },
                 reflect: function() {
                     return this;
                 }
             });
+
+        it('should be bound to store instance before init', function() {
+            return assert.equal(store, initReflect());
         });
 
         it('should be bound to store instance', function() {


### PR DESCRIPTION
Fixes #167.

I needed to update one unrelated test because the methods are bound before `this.listenToMany` runs. The alternative was moving the listenables handling earlier in the `Store()` constructor, but I was concerned that would break `init` methods that mutate `this.listenables`. As a note, `PublisherMethods.listen` is now getting passed bound store methods, so the callback binding it does is redundant for this case.