### PR TITLE
fix global namespace pollution

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,6 +3,7 @@
 
     "curly": true,
     "unused": true,
+    "undef": true,
 
     "browser": true,
     "devel": true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
     jshint: {
       files: ['Gruntfile.js', 'src/**/*.js', 'test/**/*.js'],
       options: {
-        jshintrc: '.jshintrc'
+        jshintrc: true
       }
     },
     mochaTest: {

--- a/src/ListenerMethods.js
+++ b/src/ListenerMethods.js
@@ -7,8 +7,8 @@ var _ = require('./utils'),
  *
  * @param {Object} listenable The parent listenable
  */
-mapChildListenables = function(listenable) {
-    var i = 0, children = {};
+var mapChildListenables = function(listenable) {
+    var i = 0, children = {}, childName;
     for (;i < (listenable.children||[]).length; ++i) {
         childName = listenable.children[i];
         if(listenable[childName]){
@@ -24,7 +24,7 @@ mapChildListenables = function(listenable) {
  *
  * @param {Object} listenables The top-level listenables
  */
-flattenListenables = function(listenables) {
+var flattenListenables = function(listenables) {
     var flattened = {};
     for(var key in listenables){
         var listenable = listenables[key];
@@ -171,7 +171,7 @@ module.exports = {
         defaultCallback = (defaultCallback && this[defaultCallback]) || defaultCallback;
         var me = this;
         if (_.isFunction(defaultCallback) && _.isFunction(listenable.getInitialState)) {
-            data = listenable.getInitialState();
+            var data = listenable.getInitialState();
             if (data && _.isFunction(data.then)) {
                 data.then(function() {
                     defaultCallback.apply(me, arguments);

--- a/src/joins.js
+++ b/src/joins.js
@@ -63,7 +63,7 @@ exports.instanceJoinCreator = function(strategy){
 
 function makeStopper(subobj,cancels,context){
     return function() {
-        var i, subs = context.subscriptions;
+        var i, subs = context.subscriptions,
             index = (subs ? subs.indexOf(subobj) : -1);
         _.throwIf(index === -1,'Tried to remove join already gone from subscriptions list!');
         for(i=0;i < cancels.length; i++){

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,8 +48,7 @@ exports.object = function(keys,vals){
 };
 
 exports.isArguments = function(value) {
-    return value && typeof value == 'object' && typeof value.length == 'number' &&
-      (toString.call(value) === '[object Arguments]' || (hasOwnProperty.call(value, 'callee' && !propertyIsEnumerable.call(value, 'callee')))) || false;
+    return typeof value === 'object' && ('callee' in value) && typeof value.length === 'number';
 };
 
 exports.throwIf = function(val,msg){

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,11 @@
+{
+    "extends": "../.jshintrc",
+    "globals": {
+        "describe": false,
+        "it": false,
+        "before": false,
+        "beforeEach": false,
+        "after": false,
+        "afterEach": false
+    }
+}


### PR DESCRIPTION
Just found global namespace pollution in one place.
Added `"undef": true` in `.jshintrc` to avoid this bug in future. And fixed rest pollutions