### PR TITLE
Throw error on undefined promise passed to PublisherMethods.listenAndPro...

### DIFF
--- a/src/PublisherMethods.js
+++ b/src/PublisherMethods.js
@@ -77,6 +77,11 @@ module.exports = {
         bindContext = bindContext || this;
 
         return this.listen(function() {
+
+            if (!callback) {
+                throw new Error('Expected a function returning a promise but got ' + callback);
+            }
+
             var args = arguments,
                 promise = callback.apply(bindContext, args);
             return me.promise.call(me, promise);


### PR DESCRIPTION
Handle undefined promise with a new error thrown.