### PR TITLE
IE compatibility - catch is a reserved word

### DIFF
--- a/src/PublisherMethods.js
+++ b/src/PublisherMethods.js
@@ -61,7 +61,9 @@ module.exports = {
 
         promise.then(function(response) {
             return me.completed(response);
-        }).catch(function(error) {
+        });
+        // IE compatibility - catch is a reserved word - without bracket notation source compilation will fail under IE
+        promise["catch"](function(error) {
             return me.failed(error);
         });
     },


### PR DESCRIPTION
IE compatibility - catch is a reserved word - without bracket notation source compilation will fail under IE