### PR TITLE
Rename action name property from built-in

### DIFF
--- a/src/createAction.js
+++ b/src/createAction.js
@@ -14,7 +14,7 @@ var createAction = function(definition) {
 
     definition = definition || {};
     if (!_.isObject(definition)){
-        definition = {name: definition};
+        definition = {actionName: definition};
     }
 
     for(var a in Reflux.ActionMethods){


### PR DESCRIPTION
`function.name` is a read-only property is es6. Rename to something that is writable.