### PR TITLE
Fix IE8 compatibility

### DIFF
--- a/src/PublisherMethods.js
+++ b/src/PublisherMethods.js
@@ -61,7 +61,7 @@ module.exports = {
 
         promise.then(function(response) {
             return me.completed(response);
-        }).catch(function(error) {
+        })['catch'](function(error) {
             return me.failed(error);
         });
     },


### PR DESCRIPTION
`catch` is a reserved name in IE8. Fixes #202.