### PR TITLE
Fix typo in pluralization

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Some concepts are still in Reflux in comparison with Flux:
 Reflux has refactored Flux to be a bit more dynamic and be more Functional Reactive Programming (FRP) friendly:
 
 * The singleton dispatcher is removed in favor for letting every action act as dispatcher instead.
-* Because actions are listenable, the stores may listen to them. Stores don't need to have a big switch statements that does static type checking (of action types) with strings
+* Because actions are listenable, the stores may listen to them. Stores don't need to have big switch statements that do static type checking (of action types) with strings
 * Stores may listen to other stores, i.e. it is possible to create stores that can *aggregate data further*, similar to a map/reduce.
 * `waitFor` is replaced in favor to handle *serial* and *parallel* data flows:
  * **Aggregate data stores** (mentioned above) may listen to other stores in *serial*


### PR DESCRIPTION
I fixed what looked like a cut-and-paste error in the README