### PR TITLE
Allow default params on createActions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,14 @@ exports.createActions = function(definitions) {
         var val = definitions[k],
             actionName = _.isObject(val) ? k : val;
 
+        if (!isNaN(parseFloat(actionName))) {
+            var keys = Object.keys(val);
+            if (keys.length === 1) {
+                actionName = keys[0];
+                val = val[actionName];
+            }
+        }
+
         actions[actionName] = exports.createAction(val);
     }
     return actions;

--- a/test/creatingActions.spec.js
+++ b/test/creatingActions.spec.js
@@ -318,3 +318,30 @@ describe('Creating multiple actions to an action definition object', function() 
     });
 
 });
+
+
+describe('Creating multiple actions to an action definition with mixed types', function() {
+    var actionNames, actions;
+
+    beforeEach(function () {
+        actionNames = ['foo', { 'bar' : {asyncResult: true}}];
+        actions = Reflux.createActions(actionNames);
+    });
+
+    it('should contain foo and bar properties', function () {
+        assert.property(actions, 'foo');
+        assert.property(actions, 'bar');
+    });
+
+    describe('foo action', function () {
+        it('should be sync', function () {
+            assert.equal(actions.foo.asyncResult, undefined);
+        });
+    });
+
+    describe('bar action', function () {
+        it('should be async', function () {
+            assert.equal(actions.bar.asyncResult, true);
+        });
+    });
+});

--- a/test/creatingActions.spec.js
+++ b/test/creatingActions.spec.js
@@ -319,7 +319,6 @@ describe('Creating multiple actions to an action definition object', function() 
 
 });
 
-
 describe('Creating multiple actions to an action definition with mixed types', function() {
     var actionNames, actions;
 


### PR DESCRIPTION
Closes #205 

Contrary to the suggested proposed solution in #205, this allows you to pass any attributes to use as defaults across all actions.

```js
// before
var actions = Reflux.createActions({
  'action1': { asyncResult: true },
  'action2': { asyncResult: true },
  'action3': { asyncResult: true }
})
```

```js
// after
var actions = Reflux.createActions(['action1', 'action2', 'action3'], { asyncResult: true });
```

---

As shown in the tests, these are *default* options when using the object notation - this allows you to override the "defaults" via the object notation, like:

```js
var actionNames = {'foo': {children: ['boo']}, 'bar': {children: ['baz']}, 'baz': {asyncResult: false}};
var actions = Reflux.createActions(actionNames, { asyncResult: true });
```

Here, `baz` has `asyncResult` of false, while `foo` and `bar` are true.