### PR TITLE
Allow default params on createActions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,11 +39,18 @@ var _ = require('./utils');
  * @param definitions the definitions for the actions to be created
  * @returns an object with actions of corresponding action names
  */
-exports.createActions = function(definitions) {
+exports.createActions = function(definitions, options) {
     var actions = {};
     for (var k in definitions){
         var val = definitions[k],
             actionName = _.isObject(val) ? k : val;
+
+        if (_.isObject(options)) {
+            if (!_.isObject(val)){
+                val = { actionName: val };
+            }
+            val = _.extend({}, options, val);
+        }
 
         actions[actionName] = exports.createAction(val);
     }

--- a/test/creatingActions.spec.js
+++ b/test/creatingActions.spec.js
@@ -276,6 +276,27 @@ describe('Creating actions with children to an action definition object', functi
     });
 });
 
+describe('Creating actions with universal options to an action definition object', function() {
+    var actionNames, actions;
+
+    beforeEach(function () {
+        actionNames = {'foo': {asyncResult: true}, 'bar': {children: ['baz']}, 'baz': {asyncResult: false}};
+        actions = Reflux.createActions(actionNames, { asyncResult: true });
+    });
+
+    it('should contain async foo, bar and baz properties', function () {
+        assert.property(actions, 'foo');
+        assert.property(actions, 'bar');
+        assert.property(actions, 'baz');
+    });
+
+    it('should contain async foo and bar actions', function () {
+        assert.equal(actions.foo.asyncResult, true);
+        assert.equal(actions.bar.asyncResult, true);
+        assert.equal(actions.baz.asyncResult, false);
+    });
+});
+
 describe('Creating multiple actions to an action definition object', function() {
 
     var actionNames, actions;
@@ -317,4 +338,23 @@ describe('Creating multiple actions to an action definition object', function() 
 
     });
 
+});
+
+describe('Creating multiple actions to an action definition object', function() {
+    var actionNames, actions;
+
+    beforeEach(function () {
+        actionNames = ['foo', 'bar'];
+        actions = Reflux.createActions(actionNames, { asyncResult: true });
+    });
+
+    it('should contain foo and bar properties', function() {
+        assert.property(actions, 'foo');
+        assert.property(actions, 'bar');
+    });
+
+    it('should contain async foo and bar actions', function() {
+        assert.equal(actions.foo.asyncResult, true);
+        assert.equal(actions.bar.asyncResult, true);
+    });
 });


### PR DESCRIPTION
Closes #205 

Contrary to the suggested proposed solution in #205, this allows you to pass any attributes to use as defaults across all actions.

```js
// before
var actions = Reflux.createActions({
  'action1': { asyncResult: true },
  'action2': { asyncResult: true },
  'action3': { asyncResult: true }
})
```

```js
// after
var actions = Reflux.createActions(['action1', 'action2', 'action3'], { asyncResult: true });
```

---

As shown in the tests, these are *default* options when using the object notation - this allows you to override the "defaults" via the object notation, like:

```js
var actionNames = {'foo': {children: ['boo']}, 'bar': {children: ['baz']}, 'baz': {asyncResult: false}};
var actions = Reflux.createActions(actionNames, { asyncResult: true });
```

Here, `baz` has `asyncResult` of false, while `foo` and `bar` are true.