### PR TITLE
#253 export internal Promise and EventEmitter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,12 +71,6 @@ exports.setPromise = function(ctx) {
     exports.Promise = _.Promise = ctx;
 };
 
-/**
- * Gets the Promise library that Reflux uses
- */
-exports.getPromise = function() {
-    return require('./utils').Promise;
-};
 
 /**
  * Sets the Promise factory that creates new promises

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,10 @@ exports.joinConcat = maker("all");
 
 var _ = require('./utils');
 
+exports.EventEmitter = _.EventEmitter;
+
+exports.Promise = _.Promise;
+
 /**
  * Convenience function for creating a set of actions
  *
@@ -55,7 +59,7 @@ exports.createActions = function(definitions) {
  */
 exports.setEventEmitter = function(ctx) {
     var _ = require('./utils');
-    _.EventEmitter = ctx;
+    exports.EventEmitter = _.EventEmitter = ctx;
 };
 
 
@@ -64,7 +68,14 @@ exports.setEventEmitter = function(ctx) {
  */
 exports.setPromise = function(ctx) {
     var _ = require('./utils');
-    _.Promise = ctx;
+    exports.Promise = _.Promise = ctx;
+};
+
+/**
+ * Gets the Promise library that Reflux uses
+ */
+exports.getPromise = function() {
+    return require('./utils').Promise;
 };
 
 /**

--- a/test/changingEventStore.spec.js
+++ b/test/changingEventStore.spec.js
@@ -5,16 +5,26 @@ var chai = require('chai'),
 
 chai.use(require('chai-as-promised'));
 
-describe('Switching the used EventEmitter to Node\'s internal', function() {
+describe('Export internal EventEmitter', function() {
+    it('should be the original', function() {
+        assert.equal(internalUtils.EventEmitter, Reflux.EventEmitter);
+    });
+});
 
-    beforeEach(function () {
-        // set to NodeJS's internal EventEmitter
+describe('Switching the used EventEmitter to Node\'s internal', function() {
+    var original;
+
+    beforeEach(function() {
+        original = internalUtils.EventEmitter;
         Reflux.setEventEmitter(require('events').EventEmitter);
     });
 
     afterEach(function () {
-        // reset back to eventemitter3
         Reflux.setEventEmitter(require('eventemitter3'));
+    });
+
+    it('should not be the original', function() {
+        assert.notEqual(original, Reflux.EventEmitter);
     });
 
     it('should have the same interface', function() {

--- a/test/changingPromise.spec.js
+++ b/test/changingPromise.spec.js
@@ -29,12 +29,17 @@ var MockFactory = function(resolver) {
     return new MockPromise(resolver);
 };
 
+describe('Export internal Promise', function() {
+    it('should be the original', function() {
+        assert.equal(utils.Promise, Reflux.Promise);
+    });
+});
+
 describe('Switching Promise constructor', function() {
     var original;
 
     beforeEach(function() {
         original = utils.Promise;
-
         Reflux.setPromise(MockPromise);
     });
 
@@ -44,6 +49,7 @@ describe('Switching Promise constructor', function() {
 
     it('should not be the original', function() {
         assert.notEqual(original, utils.Promise);
+        assert.notEqual(original, Reflux.Promise);
     });
 
     it('should have the same interface', function() {


### PR DESCRIPTION
Export Promise and EventEmitter to use outside of Reflux. Cool when developer is not using browserify (like me)