### PR TITLE
add common definitions for the multiple action creator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,13 +39,14 @@ var _ = require('./utils');
  * @param definitions the definitions for the actions to be created
  * @returns an object with actions of corresponding action names
  */
-exports.createActions = function(definitions) {
+exports.createActions = function(definitions, commonDefinition) {
     var actions = {};
     for (var k in definitions){
         var val = definitions[k],
-            actionName = _.isObject(val) ? k : val;
+            actionName = _.isObject(val) ? k : val,
+            definition = !commonDefinition ? val : _.isObject(val) ? _.extend(commonDefinition, val) : val;
 
-        actions[actionName] = exports.createAction(val);
+        actions[actionName] = exports.createAction(definition);
     }
     return actions;
 };

--- a/test/creatingActions.spec.js
+++ b/test/creatingActions.spec.js
@@ -318,3 +318,37 @@ describe('Creating multiple actions to an action definition object', function() 
     });
 
 });
+
+describe('Creating multiple actions to an action definition object with common properties', function() {
+
+    var actionNames, actions;
+
+    beforeEach(function () {
+        actionNames = ['foo', 'bar'];
+        actions = Reflux.createActions(actionNames, { sync: true });
+    });
+
+    it('should contain foo and bar properties', function() {
+        assert.property(actions, 'foo');
+        assert.property(actions, 'bar');
+    });
+
+    it('should contain action functor on foo and bar properties', function() {
+        assert.isFunction(actions.foo);
+        assert.isFunction(actions.bar);
+    });
+
+    describe('when listening to any of the actions created this way', function() {
+
+        it('should receive the correct arguments', function() {
+            var testArgs = [1337, 'test'],
+                spy = sinon.spy(actions, 'foo');
+
+            actions.foo(testArgs[0], testArgs[1]);
+
+            assert.deepEqual(spy.args[0], testArgs);
+        });
+
+    });
+
+});


### PR DESCRIPTION
to create actions in the such manner:

```
Reflux.createActions([
  'action1',
  'action2'
], { sync: true });
```