### PR TITLE
Let dist folder in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-dist
 node_modules
 test
 tmp


### PR DESCRIPTION
Since npm has turned a [front-end package manager](http://blog.npmjs.org/post/101775448305/npm-and-front-end-packaging), dist folder makes more sense to be exposed(the same way react does).