### PR TITLE
Fixed catch() call in PublisherMethods.promise()

### DIFF
--- a/src/PublisherMethods.js
+++ b/src/PublisherMethods.js
@@ -61,9 +61,7 @@ module.exports = {
 
         promise.then(function(response) {
             return me.completed(response);
-        });
-        // IE compatibility - catch is a reserved word - without bracket notation source compilation will fail under IE
-        promise["catch"](function(error) {
+        }, function(error) {
             return me.failed(error);
         });
     },


### PR DESCRIPTION
this fixes #265

the bug was introduced with #187 and the patch uses the suggestion by @gabro in the same PR.