### PR TITLE
Passing array to Reflux.createActions does not work in IE8

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,10 +46,12 @@ exports.Promise = _.Promise;
 exports.createActions = function(definitions) {
     var actions = {};
     for (var k in definitions){
-        var val = definitions[k],
-            actionName = _.isObject(val) ? k : val;
+        if (definitions.hasOwnProperty(k)) {
+            var val = definitions[k],
+                actionName = _.isObject(val) ? k : val;
 
-        actions[actionName] = exports.createAction(val);
+            actions[actionName] = exports.createAction(val);
+        }
     }
     return actions;
 };


### PR DESCRIPTION
When doing a `for ... in` loop on an array in IE8 it loops over all the array indices AND inherited properties such as indexOf, forEach, etc. Calling hasOwnProperty will ensure it only cares about the indices.