### PR TITLE
Fix Convenience mixin for React example

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ var Status = React.createClass({
         });
     },
     componentDidMount: function() {
-        this.listenTo(statusStore, this.onStatusChange);
+        this.listenTo(statusUpdate, this.onStatusChange);
     },
     render: function() {
         // render specifics


### PR DESCRIPTION
I only started using `refluxjs` so maybe I am missing something, but I thought that it's the `update` that we should `listenTo` rather than the `store`.