### PR TITLE
typo fix in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,10 +561,10 @@ var Status = React.createClass({
 The `Reflux.connect()` mixin will check the store for a `getInitialState` method. If found it will set the components `getInitialState`
 
 ```javascript
-var statusStore Reflux.createStore({
-	getInitialState = function(){
-		return "open"
-	}
+var statusStore = Reflux.createStore({
+    getInitialState = function() {
+        return "open"
+    }
 });
 var Status = React.createClass({
     mixins: [Reflux.connect(statusStore,"currentStatus")],


### PR DESCRIPTION
* missing = is added;
* tabs are converted to spaces, and a space before { is added - to make formatting more consistent with other examples.