### PR TITLE
Add Thinkful open sessions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A simple library for unidirectional dataflow architecture inspired by ReactJS [F
 [![Dependencies][dependencies-image]][npm-url]
 [![Build Status][travis-image]][travis-url]
 [![Gratipay][gratipay-image]][gratipay-url]
+[![Thinkful][thinkful-image]][thinkful-url]
 
 You can read an overview of Flux [here](https://facebook.github.io/flux/docs/overview.html), however the gist of it is to introduce a more functional programming style architecture by eschewing MVC like pattern and adopting a single data flow pattern.
 
@@ -774,3 +775,5 @@ This project uses [eventemitter3](https://github.com/3rd-Eden/EventEmitter3), is
 [travis-url]: https://travis-ci.org/spoike/refluxjs
 [gratipay-image]: http://img.shields.io/gratipay/spoike.svg
 [gratipay-url]: https://gratipay.com/spoike/
+[thinkful-image]: https://tf-assets-staging.s3.amazonaws.com/badges/thinkful_repo_badge.svg
+[thinkful-url]: http://start.thinkful.com/react/?utm_source=github&utm_medium=badge&utm_campaign=reflux

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A simple library for unidirectional dataflow architecture inspired by ReactJS [F
 [![Dependencies][dependencies-image]][npm-url]
 [![Build Status][travis-image]][travis-url]
 [![Gratipay][gratipay-image]][gratipay-url]
-[![Thinkful][thinkful-image]][thinkful-url]
 
 You can read an overview of Flux [here](https://facebook.github.io/flux/docs/overview.html), however the gist of it is to introduce a more functional programming style architecture by eschewing MVC like pattern and adopting a single data flow pattern.
 
@@ -28,6 +27,7 @@ For questions please use the following communication channels:
 1. [StackOverflow with the `refluxjs` tag](http://stackoverflow.com/questions/tagged/refluxjs)
 2. [`#reflux` channel](https://reactiflux.slack.com/messages/reflux/) on Reactiflux Slack group. [Sign up here](http://reactiflux.com/) for an account.
 3. [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/spoike/refluxjs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+4. [![Thinkful][thinkful-image]][thinkful-url]
 
 Please only use the [issue tracker](https://github.com/spoike/refluxjs/issues) for bugs and feature requests only.
 


### PR DESCRIPTION
Hey @spoike, @LongLiveCHIEF and Reflux community — as discussed on Reactiflux, we've been holding regular open group sessions where engineers in the React community can screenshare code and discuss questions. Right now the sessions are for React generally, but as we grow I'm hoping we can start doing hangouts just for Reflux and other community projects.

A badge on the README will help us get the word out and make the hangouts better, since the sessions only work well when a diverse group of developers show up. 

Let me know what you think!