### PR TITLE
Fix connectFilter function result condition check

### DIFF
--- a/src/connectFilter.js
+++ b/src/connectFilter.js
@@ -12,7 +12,7 @@ module.exports = function(listenable, key, filterFunc) {
             } else {
                 // Filter initial payload from store.
                 var result = filterFunc.call(this, listenable.getInitialState());
-                if (result) {
+                if (result !== undefined) {
                   return _.object([key], [result]);
                 } else {
                   return {};


### PR DESCRIPTION
- Fixes the bug: If the filter function rendered a result like `0`, `""`, `false`, it fails to render with correct state.